### PR TITLE
Avoid Spotify zombie process

### DIFF
--- a/spotify.1l.1s.py
+++ b/spotify.1l.1s.py
@@ -23,7 +23,7 @@ startUri = 'spotify:track:3sXHMpriGlbFhMdJT6tzao'
 # Check if process name is running
 def isRunning(name):
     for proc in psutil.process_iter():
-        if(proc.name() == name):
+        if(proc.name() == name and proc.status() != psutil.STATUS_ZOMBIE):
             return True
 
 # Shorten strings longer than maxDisplayLength to maxDisplayLength and add ... after


### PR DESCRIPTION
Because of this bug
https://bugzilla.redhat.com/show_bug.cgi?id=1101976
the "isRunning" method detects a zombie "Spotify" process as running, later generating an error on the "session_bus.get_object" method call (line 43).
The proposed fix adds a check on the process status.